### PR TITLE
Add basic rewrite rule for PHPDocumentor → apigen URLs

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -9,3 +9,7 @@ RewriteRule ^(sapphire|cms|forms|default)/(.*) /current/$1/$2 [R=301]
 RewriteRule ^current/?(.*)? /2.4/$1 [R=301]
 # Rewrite old ecommerce links
 RewriteRule ^ecommerce/?(.*)? /modules/ecommerce/trunk/$1 [R=301]
+
+# Rewrite PHPDocumentor links for apigen
+RewriteCond %{REQUEST_FILENAME} !^class-
+RewriteRule ^/?(trunk|[23]\.[0-9])/.*/(.+)\.html$ /$1/class-$2.html [L,R=301]


### PR DESCRIPTION
Here is the basic rewrite. As Ingo stated in the dev group, we're not (yet) accounting for anchors or secondary views.
