### PR TITLE
FIX: Method details now show onclick

### DIFF
--- a/conf/apigen/templates/js/main.js
+++ b/conf/apigen/templates/js/main.js
@@ -145,7 +145,7 @@ $(function() {
 			.click(function() {
 				var $this = $(this);
 				$('.short', $this).hide();
-				$('.detailed', $this).show();
+				$('.detailed', $this).show().css("visibility", "visible");
 			});
 	}
 

--- a/htdocs/master/resources/combined.js
+++ b/htdocs/master/resources/combined.js
@@ -1127,7 +1127,7 @@ $(function() {
 			.click(function() {
 				var $this = $(this);
 				$('.short', $this).hide();
-				$('.detailed', $this).show();
+				$('.detailed', $this).show().css("visibility", "visible");
 			});
 	}
 


### PR DESCRIPTION
Simple JS fix to show method details on click, previously caused by bootstrap.css's .hidden{visibility:hidden;} rule.
