### PR TITLE
Allow for fixed header when scrolling to anchor linked range of code

### DIFF
--- a/conf/apigen/templates/js/main.js
+++ b/conf/apigen/templates/js/main.js
@@ -221,7 +221,7 @@ $(function() {
 
 		var $firstLine = $('#' + parseInt(matches[0]));
 		if ($firstLine.length > 0) {
-			$right.scrollTop($firstLine.offset().top);
+			$right.scrollTop($firstLine.offset().top - 150);
 		}
 	}
 


### PR DESCRIPTION
Due to the new ssorg header added to api pages, anchor links to a range of lines (which are handled by JavaScript) are not scrolling to the correct location on the page, resulting in the highlighted code being hidden behind the header.
