### PR TITLE
BUG: Fix for broken stylesheet path for the global toolbar

### DIFF
--- a/conf/apigen/templates/@layout.latte
+++ b/conf/apigen/templates/@layout.latte
@@ -37,7 +37,7 @@ the file LICENSE.md that was distributed with this source code.
 	<link n:if="$config->googleCseId" rel="search" type="application/opensearchdescription+xml" title="{$config->title}" href="{$config->baseUrl}/opensearch.xml">
 
 	{* CUSTOM: Toolbar support *}
-	<link rel="stylesheet" type="text/css" href="http://ssorg-another.test.silverstripe.com/themes/ssv3/css/toolbar.css" />
+	<link rel="stylesheet" type="text/css" href="http://www.silverstripe.org/themes/ssv3/css/toolbar.css" />
 
 	{* CUSTOM: CSS *}
 	{var customCss = 'resources/custom.css'}


### PR DESCRIPTION
Looks like disabling the ss.org test site has rendered the api docs pretty unusable, this pull changes the path to the toolbar stylesheet to look at www.silverstripe.org instead of the test site.
