### PR TITLE
FIX API should default to the current stable version

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -4,7 +4,7 @@ RewriteEngine On
 RewriteRule ^current/?(.*)? /3.1/$1 [R=301]
 
 # "Symlink" the root to the latest release (with "moved temporarily")
-RewriteRule ^/?$ /3.2/ [R=302,L]
+RewriteRule ^/?$ /3.1/ [R=302,L]
 
 # Lookup script (used to be a SS app, now just a simple script)
 RewriteCond %{REQUEST_URI} !^/search/lookup\.php


### PR DESCRIPTION
@tractorcow looking back at the past versions seems this needs to be set to 3.1 to have this show up as the default.