### PR TITLE
NEW Include properties tagged as `@config`

### DIFF
--- a/conf/sami.php
+++ b/conf/sami.php
@@ -39,6 +39,11 @@ $sami = new Sami($iterator, [
     'template_dirs' => [ __DIR__ .'/themes' ],
 ]);
 
+// Make sure we document `@config` options
+$sami['filter'] = function() {
+    return new \SilverStripe\ApiDocs\Parser\Filter\SilverStripeFilter();
+};
+
 // Override twig
 /** @var Twig_Environment $twig */
 $twig = $sami['twig'];

--- a/conf/sami.php
+++ b/conf/sami.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
 use Sami\Project;
 use Sami\Sami;
 use SilverStripe\ApiDocs\Data\ApiJsonStore;
@@ -42,6 +44,18 @@ $sami = new Sami($iterator, [
 // Make sure we document `@config` options
 $sami['filter'] = function() {
     return new \SilverStripe\ApiDocs\Parser\Filter\SilverStripeFilter();
+};
+
+$sami['php_traverser'] = function ($sc) {
+    $traverser = new NodeTraverser();
+    $traverser->addVisitor(new NameResolver());
+    $traverser->addVisitor(new \SilverStripe\ApiDocs\Parser\SilverStripeNodeVisitor($sc['parser_context']));
+
+    return $traverser;
+};
+
+$sami['renderer'] = function ($sc) {
+    return new \SilverStripe\ApiDocs\Renderer\SilverStripeRenderer($sc['twig'], $sc['themes'], $sc['tree'], $sc['indexer']);
 };
 
 // Override twig

--- a/conf/themes/silverstripe/class.twig
+++ b/conf/themes/silverstripe/class.twig
@@ -55,6 +55,12 @@
         {{ block('constants') }}
     {% endif %}
 
+    {% if configs %}
+        <h2>Config options</h2>
+
+        {{ block('configs') }}
+    {% endif %}
+
     {% if properties %}
         <h2>Properties</h2>
 
@@ -157,6 +163,28 @@
                 <td class="last">
                     <p><em>{{ constant.shortdesc|desc(class) }}</em></p>
                     <p>{{ constant.longdesc|desc(class) }}</p>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endblock %}
+
+{% block configs %}
+    <table class="table table-condensed">
+        {% for config in configs %}
+            <tr>
+                <td class="type" id="config_{{ config.name|raw }}">
+                    {% if config.protected %}protected{% endif %}
+                    {% if config.private %}private{% endif %}
+                    {% if config.static %}static{% endif %}
+                    {{ hint_link(config.hint) }}
+                </td>
+                <td>${{ config.name|raw }}</td>
+                <td class="last">{{ config.shortdesc|desc(class) }}</td>
+                <td>
+                    {%- if config.class is not same as(class) -%}
+                        <small>from&nbsp;{{ property_link(property, false, true) }}</small>
+                    {%- endif -%}
                 </td>
             </tr>
         {% endfor %}

--- a/src/Parser/Filter/SilverStripeFilter.php
+++ b/src/Parser/Filter/SilverStripeFilter.php
@@ -11,17 +11,18 @@ class SilverStripeFilter extends PublicFilter
 {
     public function acceptClass(ClassReflection $class)
     {
-        return parent::acceptClass($class);
+        return !$class->getTags('internal') && parent::acceptClass($class);
     }
 
     public function acceptMethod(MethodReflection $method)
     {
-        return parent::acceptMethod($method);
+        return !$method->getTags('internal') && parent::acceptMethod($method);
     }
 
     public function acceptProperty(PropertyReflection $property)
     {
         // if there's a config tag, then we want to document it
-        return $property->getTags('config') || parent::acceptProperty($property);
+        return !$property->getTags('internal') &&
+            ($property->getTags('config') || parent::acceptProperty($property));
     }
 }

--- a/src/Parser/Filter/SilverStripeFilter.php
+++ b/src/Parser/Filter/SilverStripeFilter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\ApiDocs\Parser\Filter;
+
+use Sami\Parser\Filter\PublicFilter;
+use Sami\Reflection\ClassReflection;
+use Sami\Reflection\MethodReflection;
+use Sami\Reflection\PropertyReflection;
+
+class SilverStripeFilter extends PublicFilter
+{
+    public function acceptClass(ClassReflection $class)
+    {
+        return parent::acceptClass($class);
+    }
+
+    public function acceptMethod(MethodReflection $method)
+    {
+        return parent::acceptMethod($method);
+    }
+
+    public function acceptProperty(PropertyReflection $property)
+    {
+        // if there's a config tag, then we want to document it
+        return $property->getTags('config') || parent::acceptProperty($property);
+    }
+}

--- a/src/Parser/SilverStripeNodeVisitor.php
+++ b/src/Parser/SilverStripeNodeVisitor.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SilverStripe\ApiDocs\Parser;
+
+use Prophecy\Doubler\Generator\Node\ClassNode;
+use Sami\Parser\NodeVisitor;
+use PhpParser\Node\Stmt\ClassLike as ClassLikeNode;
+use PhpParser\Node\Stmt\Property as PropertyNode;
+use Sami\Reflection\PropertyReflection;
+use SilverStripe\ApiDocs\Reflection\SilverStripeClassReflection;
+
+class SilverStripeNodeVisitor extends NodeVisitor
+{
+    protected function addClassOrInterface(ClassLikeNode $node)
+    {
+        $class = new SilverStripeClassReflection((string) $node->namespacedName, $node->getLine());
+        if ($node instanceof ClassNode) {
+            $class->setModifiers($node->flags);
+        }
+        $class->setNamespace($this->context->getNamespace());
+        $class->setAliases($this->context->getAliases());
+        $class->setHash($this->context->getHash());
+        $class->setFile($this->context->getFile());
+
+        $comment = $this->context->getDocBlockParser()->parse($node->getDocComment(), $this->context, $class);
+        $class->setDocComment($node->getDocComment());
+        $class->setShortDesc($comment->getShortDesc());
+        $class->setLongDesc($comment->getLongDesc());
+        if ($errors = $comment->getErrors()) {
+            $class->setErrors($errors);
+        } else {
+            $class->setTags($comment->getOtherTags());
+        }
+
+        if ($this->context->getFilter()->acceptClass($class)) {
+            if ($errors) {
+                $this->context->addErrors((string) $class, $node->getLine(), $errors);
+            }
+            $this->context->enterClass($class);
+        }
+
+        return $class;
+    }
+
+    protected function addProperty(PropertyNode $node)
+    {
+        foreach ($node->props as $prop) {
+            $property = new PropertyReflection($prop->name, $prop->getLine());
+            $property->setModifiers($node->flags);
+
+            $property->setDefault($prop->default);
+
+            $comment = $this->context->getDocBlockParser()->parse($node->getDocComment(), $this->context, $property);
+            $property->setDocComment($node->getDocComment());
+            $property->setShortDesc($comment->getShortDesc());
+            $property->setLongDesc($comment->getLongDesc());
+            if ($errors = $comment->getErrors()) {
+                $property->setErrors($errors);
+            } else {
+                if ($tag = $comment->getTag('var')) {
+                    $property->setHint($this->resolveHint($tag[0][0]));
+                    $property->setHintDesc($tag[0][1]);
+                }
+
+                $property->setTags($comment->getOtherTags());
+            }
+
+            if ($this->context->getFilter()->acceptProperty($property)) {
+                if ($property->getTags('config')) {
+                    $this->context->getClass()->addConfig($property);
+                } else {
+                    $this->context->getClass()->addProperty($property);
+                }
+
+                if ($errors) {
+                    $this->context->addErrors((string) $property, $prop->getLine(), $errors);
+                }
+            }
+        }
+    }
+}

--- a/src/Reflection/SilverStripeClassReflection.php
+++ b/src/Reflection/SilverStripeClassReflection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\ApiDocs\Reflection;
+
+use Sami\Reflection\ClassReflection;
+use Sami\Reflection\PropertyReflection;
+
+class SilverStripeClassReflection extends ClassReflection
+{
+    const CATEGORY_CONFIG = 4;
+
+    private static $categoryName = [
+        1 => 'class',
+        2 => 'interface',
+        3 => 'trait',
+        4 => 'config',
+    ];
+
+    protected $configs = [];
+
+    public function addConfig(PropertyReflection $property)
+    {
+        $this->configs[$property->getName()] = $property;
+        $property->setClass($this);
+    }
+
+    public function getConfigs()
+    {
+        return $this->configs;
+    }
+}

--- a/src/Renderer/SilverStripeRenderer.php
+++ b/src/Renderer/SilverStripeRenderer.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace SilverStripe\ApiDocs\Renderer;
+
+use Sami\Message;
+use Sami\Project;
+use Sami\Renderer\Renderer;
+use SilverStripe\ApiDocs\Reflection\SilverStripeClassReflection;
+
+class SilverStripeRenderer extends Renderer
+{
+    protected function renderClassTemplates(array $classes, Project $project, $callback = null)
+    {
+        foreach ($classes as $class) {
+            if (null !== $callback) {
+                call_user_func(
+                    $callback,
+                    Message::RENDER_PROGRESS,
+                    array('Class', $class->getName(), $this->getProgression())
+                );
+            }
+
+            $properties = $class->getProperties($project->getConfig('include_parent_data'));
+
+            $sortProperties = $project->getConfig('sort_class_properties');
+            if ($sortProperties) {
+                if (is_callable($sortProperties)) {
+                    uksort($properties, $sortProperties);
+                } else {
+                    ksort($properties);
+                }
+            }
+
+            if ($class instanceof SilverStripeClassReflection) {
+                $configs = $class->getConfigs($project->getConfig('include_parent_data'));
+                if ($sortProperties) {
+                    if (is_callable($sortProperties)) {
+                        uksort($configs, $sortProperties);
+                    } else {
+                        ksort($properties);
+                    }
+                }
+            } else {
+                $configs = array();
+            }
+
+            $methods = $class->getMethods($project->getConfig('include_parent_data'));
+
+            $sortMethods = $project->getConfig('sort_class_methods');
+            if ($sortMethods) {
+                if (is_callable($sortMethods)) {
+                    uksort($methods, $sortMethods);
+                } else {
+                    ksort($methods);
+                }
+            }
+
+            $constants = $class->getConstants($project->getConfig('include_parent_data'));
+
+            $sortConstants = $project->getConfig('sort_class_constants');
+            if ($sortConstants) {
+                if (is_callable($sortConstants)) {
+                    uksort($constants, $sortConstants);
+                } else {
+                    ksort($constants);
+                }
+            }
+
+            $traits = $class->getTraits($project->getConfig('include_parent_data'));
+
+            $sortTraits = $project->getConfig('sort_class_traits');
+            if ($sortTraits) {
+                if (is_callable($sortTraits)) {
+                    uksort($traits, $sortTraits);
+                } else {
+                    ksort($traits);
+                }
+            }
+
+            $sortInterfaces = $project->getConfig('sort_class_interfaces');
+            if ($sortInterfaces) {
+                $class->sortInterfaces($sortInterfaces);
+            }
+
+            $variables = array(
+                'class' => $class,
+                'properties' => $properties,
+                'configs' => $configs,
+                'methods' => $methods,
+                'constants' => $constants,
+                'traits' => $traits,
+                'tree' => $this->getTree($project),
+            );
+
+            foreach ($this->theme->getTemplates('class') as $template => $target) {
+                $this->save(
+                    $project,
+                    sprintf($target, str_replace('\\', '/', $class->getName())),
+                    $template,
+                    $variables
+                );
+            }
+        }
+    }
+
+    private function getTree(Project $project)
+    {
+        $key = $project->getBuildDir();
+        if (!isset($this->cachedTree[$key])) {
+            $this->cachedTree[$key] = $this->tree->getTree($project);
+        }
+
+        return $this->cachedTree[$key];
+    }
+}


### PR DESCRIPTION
Fixes #74

Adds `private static` vars (and others) that are marked as `@config`.

![2018-06-26_14-33-41_6565efc4-4e3e-4b3e-ac51-e9d720744c37](https://user-images.githubusercontent.com/563596/41915700-40b9f2ca-794e-11e8-974f-d6d11a69923b.png)

Further optional enhancements:

- [x] Ignore methods/properties tagged as ~~`@private`~~ `@internal` (I believe we use that to indicate an API is not "public" and so outside bounds of semver
- [x] Group configs into a separate section of the page (rather than under properties)

~~I'm currently looking into grouping configs separately to properties, I'm 50/50 on whether it's going to be possible~~ it's done :)