### PR TITLE
Dont rely on typeahead classes to select the search box

### DIFF
--- a/conf/themes/silverstripe/search.twig
+++ b/conf/themes/silverstripe/search.twig
@@ -35,7 +35,7 @@
 {% block js_search %}
     <script type="text/javascript">
 
-        (function() {
+        $(function() {
             var term = Sami.cleanSearchTerm();
 
             if (!term) {
@@ -83,6 +83,6 @@
                 contents += '</div></li>';
                 container.append($(contents));
             }
-        })();
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
Fixes #78 

This fixes the issue completely. For some reason the search input hadn't been converted to a typeahead input before the bloodhoud object was instantiated.