### PR TITLE
FIX Make search results on search page sorted

### DIFF
--- a/conf/themes/silverstripe/sami.js.twig
+++ b/conf/themes/silverstripe/sami.js.twig
@@ -117,7 +117,7 @@ window.projectVersion = '{{ project.version }}';
                     queryTokenizer: Bloodhound.tokenizers.whitespace,
                     sorter: function(a, b) {
                         // not sure how to get the search term in a nicer way than this
-                        var term = searchField.val();
+                        var term = searchField.val() || Sami.cleanSearchTerm();
 
                         var lowerTerm = term.toLowerCase();
 


### PR DESCRIPTION
Search results on the search page are not sorted at the moment because the input box doesn't contain the search term. This fetches the search term from the URL if it's available