### PR TITLE
BUG Point our open search settings to the correct URL

### DIFF
--- a/conf/themes/silverstripe/opensearch.twig
+++ b/conf/themes/silverstripe/opensearch.twig
@@ -7,7 +7,7 @@
         {% if project.config('favicon') -%}
             <Image height="16" width="16" type="image/x-icon">{{ project.config('favicon') }}</Image>
         {% endif %}
-        <Url type="text/html" method="GET" template="{{ project.config('base_url')|replace({'%version%': project.version}) ~ '/index.html?q={searchTerms}&src={referrer:source?}' }}"/>
+        <Url type="text/html" method="GET" template="{{ project.config('base_url')|replace({'%version%': project.version}) ~ '/search.html?search={searchTerms}&src={referrer:source?}' }}"/>
         <InputEncoding>UTF-8</InputEncoding>
         <AdultContent>false</AdultContent>
     </OpenSearchDescription>


### PR DESCRIPTION
We got some open search settings built into the api doc however it doesn't point to the correct URL.

# Parent issue
* https://github.com/silverstripe/api.silverstripe.org/issues/85