### PR TITLE
mangle paths and such to get source code links back

### DIFF
--- a/conf/doctum.php
+++ b/conf/doctum.php
@@ -2,12 +2,12 @@
 
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
-use Doctum\Project;
 use Doctum\Doctum;
 use SilverStripe\ApiDocs\Data\ApiJsonStore;
 use SilverStripe\ApiDocs\Data\Config;
 use SilverStripe\ApiDocs\Inspections\RecipeFinder;
 use SilverStripe\ApiDocs\Inspections\RecipeVersionCollection;
+use SilverStripe\ApiDocs\SilverStripeProject;
 use SilverStripe\ApiDocs\Twig\NavigationExtension;
 
 // Get config
@@ -76,7 +76,7 @@ $doctum['store'] = function () {
 // Override project
 unset($doctum['project']);
 $doctum['project'] = function ($sc) {
-    $project = new Project($sc['store'], $sc['_versions'], array(
+    $project = new SilverStripeProject($sc['store'], $sc['_versions'], array(
         'build_dir' => $sc['build_dir'],
         'cache_dir' => $sc['cache_dir'],
         'remote_repository' => $sc['remote_repository'],

--- a/src/Parser/SilverStripeNodeVisitor.php
+++ b/src/Parser/SilverStripeNodeVisitor.php
@@ -21,6 +21,7 @@ class SilverStripeNodeVisitor extends NodeVisitor
         $class->setAliases($this->context->getAliases());
         $class->setHash($this->context->getHash());
         $class->setFile($this->context->getFile());
+        $class->setRelativeFilePath($this->context->getFile());
 
         $comment = $this->context->getDocBlockParser()->parse($node->getDocComment(), $this->context, $class);
         $class->setDocComment($node->getDocComment());

--- a/src/Reflection/SilverStripeClassReflection.php
+++ b/src/Reflection/SilverStripeClassReflection.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ApiDocs\Reflection;
 
 use Doctum\Reflection\ClassReflection;
 use Doctum\Reflection\PropertyReflection;
+use SilverStripe\ApiDocs\Data\Config;
 
 class SilverStripeClassReflection extends ClassReflection
 {
@@ -27,5 +28,19 @@ class SilverStripeClassReflection extends ClassReflection
     public function getConfigs()
     {
         return $this->configs;
+    }
+
+    public function getSourcePath($line = null)
+    {
+        $config = Config::getConfig();
+        $realPackagePath = realpath(Config::configPath($config['paths']['packages']));
+        $realRelativeFilePath = realpath($this->relativeFilePath);
+        $filePath = substr($realRelativeFilePath, strlen($realPackagePath) + 1);
+        $parts = explode('/', $filePath);
+        $package = "{$parts[0]}/{$parts[1]}";
+        $this->project->setRemoteRepository($config['packages'][$package]['repository']);
+        $relativePathFromPackage = substr($filePath, strlen($package));
+
+        return $this->project->getViewSourceUrl($relativePathFromPackage, $line);
     }
 }

--- a/src/SilverStripeProject.php
+++ b/src/SilverStripeProject.php
@@ -1,0 +1,25 @@
+<?php
+namespace SilverStripe\ApiDocs;
+
+use Doctum\Project;
+use Doctum\RemoteRepository\GitHubRemoteRepository;
+use SilverStripe\ApiDocs\Data\Config;
+
+class SilverStripeProject extends Project
+{
+    public function setRemoteRepository($remoteRepositoryName)
+    {
+        if (strpos($remoteRepositoryName, 'https://github.com/') !== false) {
+            $remoteRepositoryName = substr($remoteRepositoryName, strlen('https://github.com/'));
+        }
+
+        if (substr($remoteRepositoryName, -4) === '.git') {
+            $remoteRepositoryName = substr($remoteRepositoryName, 0, -4);
+        }
+
+        $this->config['remote_repository'] = new GitHubRemoteRepository(
+            $remoteRepositoryName,
+            Config::getConfig()['paths']['packages'] . "/{$remoteRepositoryName}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #59 

Does some mangling to get the view source links back.

Haven't tested whether it works for references across repos (i.e. a CMS class that gets a method from Framework) but it's a start.

Fully aware it's ugly and tightly coupled 👍 