### PR TITLE
MNT Show graphql v4 classes in api.silverstripe.org

### DIFF
--- a/conf/doctum.json
+++ b/conf/doctum.json
@@ -44,8 +44,7 @@
             "repository": "https://github.com/silverstripe/silverstripe-framework.git"
         },
         "silverstripe/graphql": {
-            "repository": "https://github.com/silverstripe/silverstripe-graphql.git",
-            "versionmap": "starts-at-three"
+            "repository": "https://github.com/silverstripe/silverstripe-graphql.git"
         },
         "silverstripe/reports": {
             "repository": "https://github.com/silverstripe/silverstripe-reports.git"

--- a/tests/SilverStripeRemoteRepositoryTest.php
+++ b/tests/SilverStripeRemoteRepositoryTest.php
@@ -27,25 +27,25 @@ class SilverStripeRemoteRepositoryTest extends TestCase
 
         $url = $remoteRepo->getFileUrl(
             '4',
-            'silverstripe/graphql/src/Extensions/IntrospectionProvider.php',
+            'silverstripe/graphql/src/Extensions/DevBuildExtension.php',
             0
         );
 
         $this->assertSame(
             'https://github.com/silverstripe/'
-            . 'silverstripe-graphql/blob/3/src/Extensions/IntrospectionProvider.php#L0',
+            . 'silverstripe-graphql/blob/4/src/Extensions/DevBuildExtension.php#L0',
             $url
         );
 
         $url = $remoteRepo->getFileUrl(
             'master',
-            'silverstripe/graphql/src/Extensions/IntrospectionProvider.php',
+            'silverstripe/graphql/src/Extensions/DevBuildExtension.php',
             0
         );
 
         $this->assertSame(
             'https://github.com/silverstripe/'
-            . 'silverstripe-graphql/blob/master/src/Extensions/IntrospectionProvider.php#L0',
+            . 'silverstripe-graphql/blob/master/src/Extensions/DevBuildExtension.php#L0',
             $url
         );
 


### PR DESCRIPTION
The documentation for v4 references some of this API - now that v4 is going to have a stable release we should show its classes on the site.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/519