### PR TITLE
FIX Use "mysite" for platform vhost value.

### DIFF
--- a/.platform.yml
+++ b/.platform.yml
@@ -11,7 +11,7 @@ crons:
   mytask:
     time: "0 3 * * *"
     command: "/var/www/mysite/www/makedoc.sh | logger -t SilverStripe_cron"
-    vhost: "ssapi2"
+    vhost: "mysite"
 url_rules:
   mysite:
     - '^.*': 'apache'


### PR DESCRIPTION
"mysite" is required for non-vhost stacks.

This change has already been deployed in UAT. After merging, tag 4.2.2 and deploy to prod.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/554