### PR TITLE
DEP Upgrade to PHP 7.4 explicitly

### DIFF
--- a/.platform.yml
+++ b/.platform.yml
@@ -1,6 +1,6 @@
 infrastructure: ^3
 php_settings:
-  version: 7.3
+  version: 7.4
   cli:
     max_execution_time: 0
 shared_dirs:

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.20",
+        "php": "^7.4",
         "gitonomy/gitlib": "~1.0",
         "symfony/console": "^3.3",
         "code-lts/doctum": "^5.4"


### PR DESCRIPTION
Fixes this error found in UAT error logs:

> Parse error: syntax error, unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in /var/www/mysite/releases/b1113f5fcebbb325cdc3a8019f2c6597d58af11e/src/Console/CheckoutCommand.php on line 21

I could just remove the typehint, but it seems better to just upgrade to PHP 7.4 since that's what I was developing on so a) we know it works and b) it's got security fixes that aren't in 7.3

There's a separate card to upgrade to 8.1 in the future, but that's more work so is out of scope right now. This PR is primarily aimed at getting the code from https://github.com/silverstripe/api.silverstripe.org/pull/107 running in ss cloud.

## Issue
- https://github.com/silverstripe/api.silverstripe.org/issues/104