### PR TITLE
ENH Add exclusion for startup-theme which has no API to document

### DIFF
--- a/src/Console/CheckoutCommand.php
+++ b/src/Console/CheckoutCommand.php
@@ -24,6 +24,7 @@ class CheckoutCommand extends Command
         '/^silverstripe\/developer-docs$/',
         '/^silverstripe\/installer$/',
         '/^silverstripe-themes\/simple$/',
+        '/^silverstripe\/startup-theme$/',
         '/^silverstripe\/vendor-plugin$/',
         '/^silverstripe\/recipe-.*/',
         '/-theme$/',


### PR DESCRIPTION
## Issue
- https://github.com/silverstripe/startup-theme/issues/7